### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: :index
 
   def index
-    @product = Product.all.order(created_at: 'DESC')
+    @products = Product.all.order(created_at: 'DESC')
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: :index
 
   def index
+    @product = Product.all.order(created_at: "DESC")
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: :index
 
   def index
-    @product = Product.all.order(created_at: "DESC")
+    @product = Product.all.order(created_at: 'DESC')
   end
 
   def new

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -7,7 +7,7 @@ class Product < ApplicationRecord
   belongs_to :shipping_day
 
   belongs_to :user
-  has_one_attached :image
+  has_one_attached :image , dependent: :destroy
 
   with_options presence: true do
     validates     :image

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -7,7 +7,7 @@ class Product < ApplicationRecord
   belongs_to :shipping_day
 
   belongs_to :user
-  has_one_attached :image , dependent: :destroy
+  has_one_attached :image, dependent: :destroy
   has_one :purchase_order
 
   with_options presence: true do

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -8,6 +8,7 @@ class Product < ApplicationRecord
 
   belongs_to :user
   has_one_attached :image , dependent: :destroy
+  has_one :purchase_order
 
   with_options presence: true do
     validates     :image

--- a/app/models/purchase_order.rb
+++ b/app/models/purchase_order.rb
@@ -1,0 +1,2 @@
+class PurchaseOrder < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :products
+  has_many :purchase_orders
 
   with_options presence: true do
     validates :nickname

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,7 +128,7 @@
     </div>
     <ul class='item-lists'>
 
-      <% @product.each do |product| %>
+      <% @products.each do |product| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,11 +128,11 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @product.each do |product| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag product.image, alt: "item-sample.png", class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -143,10 +143,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= product.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= product.price %>円<br><%= product.shipping_cost.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -155,9 +155,9 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% end %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <% if @product == [] %>
       <%# 商品がある場合は表示されないようにしましょう %>
       <li class='list'>
         <%= link_to '#' do %>
@@ -176,7 +176,7 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
+      <% end %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -134,11 +134,11 @@
         <div class='item-img-content'>
           <%= image_tag product.image, alt: "item-sample.png", class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
+          <% if product.purchase_order != nil %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
+          <% end %>
 
         </div>
         <div class='item-info'>

--- a/db/migrate/20220518071808_create_purchase_orders.rb
+++ b/db/migrate/20220518071808_create_purchase_orders.rb
@@ -1,0 +1,9 @@
+class CreatePurchaseOrders < ActiveRecord::Migration[6.0]
+  def change
+    create_table :purchase_orders do |t|
+      t.references    :user,         null: false,  foreign_key: true
+      t.references    :product,      null: false,  foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_17_221528) do
+ActiveRecord::Schema.define(version: 2022_05_18_071808) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -48,6 +48,15 @@ ActiveRecord::Schema.define(version: 2022_05_17_221528) do
     t.index ["user_id"], name: "index_products_on_user_id"
   end
 
+  create_table "purchase_orders", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "product_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["product_id"], name: "index_purchase_orders_on_product_id"
+    t.index ["user_id"], name: "index_purchase_orders_on_user_id"
+  end
+
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -68,4 +77,6 @@ ActiveRecord::Schema.define(version: 2022_05_17_221528) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "products", "users"
+  add_foreign_key "purchase_orders", "products"
+  add_foreign_key "purchase_orders", "users"
 end

--- a/spec/factories/purchase_orders.rb
+++ b/spec/factories/purchase_orders.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :purchase_order do
+    
+  end
+end

--- a/spec/factories/purchase_orders.rb
+++ b/spec/factories/purchase_orders.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :purchase_order do
-    
   end
 end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Product, type: :model do
       it 'ユーザ情報がなけれな出品できない' do
         @product.user = nil
         @product.valid?
-        expect(@product.errors.full_messages).to include("User must exist")
+        expect(@product.errors.full_messages).to include('User must exist')
       end
     end
   end

--- a/spec/models/purchase_order_spec.rb
+++ b/spec/models/purchase_order_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe PurchaseOrder, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
#what
出品された商品がトップページに表示されるように実装。

#why
・トップページに出品した情報の「画像、商品名、価格、配送料負担」を降順表示で実装。
・出品データがない場合は、ダミーデータを表示するように実装。
・売却済みのデータは、「sold out」と文字が表示されるように実装するために購入テーブルを実装。

【実施動画】
・商品データがない場合の動画：https://gyazo.com/3c975aba0ef5c34bbf399c1046ebcc9f
・商品データがある場合の動画：https://gyazo.com/ae9f6caa340e72ec1016e28064529b25
