### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,11 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @product = Product.find(params[:id])
+  end
+
+  
   private
 
   def product_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -22,7 +22,6 @@ class ItemsController < ApplicationController
     @product = Product.find(params[:id])
   end
 
-
   private
 
   def product_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: :index
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
     @products = Product.all.order(created_at: 'DESC')
@@ -22,7 +22,7 @@ class ItemsController < ApplicationController
     @product = Product.find(params[:id])
   end
 
-  
+
   private
 
   def product_params

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -158,7 +158,6 @@
       <% end %>
 
       <% if @product == [] %>
-      <%# 商品がある場合は表示されないようにしましょう %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -177,7 +176,6 @@
         <% end %>
       </li>
       <% end %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,7 +130,7 @@
 
       <% @products.each do |product| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(product) do %>
         <div class='item-img-content'>
           <%= image_tag product.image, alt: "item-sample.png", class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -30,7 +30,7 @@
       <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
 
     <% elsif user_signed_in? && @product.user_id != current_user.id %>
-    
+
       <% if @product.purchase_order == nil %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
       <% end %>
@@ -103,9 +103,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
   <a href="#" class="another-item"><%= @product.category.name %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,14 +25,15 @@
 
     <% if user_signed_in? && @product.user_id == current_user.id %>
 
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <p class="or-text">or</p>
+      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
 
-    <% if user_signed_in? && @product.user_id == current_user.id && @product.purchase_order != nil %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <% end %>
-
+    <% elsif user_signed_in? && @product.user_id != current_user.id %>
+    
+      <% if @product.purchase_order == nil %>
+        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+      <% end %>
 
     <% end %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,18 +23,20 @@
       </span>
     </div>
 
-    <% if user_signed_in? && @product.user_id == current_user.id %>
+    <% if user_signed_in? %>
+      <% if @product.user_id == current_user.id %> 
 
       <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
       <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
 
-    <% elsif user_signed_in? && @product.user_id != current_user.id %>
+      <% else %>
 
-      <% if @product.purchase_order == nil %>
-        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+        <% if @product.purchase_order == nil %>
+          <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+        <% end %>
+        
       <% end %>
-
     <% end %>
 
     <div class="item-explain-box">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,47 +23,47 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% if user_signed_in? && @product.user_id == current_user.id %>
 
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
 
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
+    <% if user_signed_in? && @product.user_id == current_user.id && @product.purchase_order != nil %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
 
 
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @product.detail %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @product.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @product.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @product.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @product.shipping_cost.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @product.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @product.shipping_day.name %></td>
         </tr>
       </tbody>
     </table>
@@ -103,7 +103,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @product.category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,22 +4,22 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @product.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <%= image_tag @product.image, alt: "item-sample.png" ,class:"item-box-img" %>
+      <% if @product.purchase_order != nil %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= "¥ #{@product.price}" %> 
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%=  @product.shipping_cost.name %>
       </span>
     </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: 'items#index'
-  resources 'items', only: [:index, :new, :create]
+  resources 'items', only: [:index, :new, :create, :show]
 end


### PR DESCRIPTION
#what
商品詳細表示ページにて、商品詳細情報を実装。

#why
・出品登録時の入力情報が表示されるように実装。
・出品者の場合は、編集、削除ができるように実装。
・出品者以外、かつ購入されていない場合は、購入画面に進むボタンを実装。
・ログオフ状態では、編集、削除、購入ができないように実装。
(売却済みによる画面表示は、購入画面実装後に実装予定)

【実施動画】
・出品者本人が出品アイテムを詳細情報を表示した場合の動画：https://gyazo.com/2f9565b2eb5720e49376be97953e764b
・出品者以外が出品アイテムを詳細情報を表示した場合の動画：https://gyazo.com/77c403c4ccbd3e16812b614ebc36dad0
・ログオフ状態で出品アイテムの詳細情報を表示した場合の動画：https://gyazo.com/68b8d5460bb9e56ba6c3791e35a7ef55

※売却済みのケースは、購入機能未実装のため未実施